### PR TITLE
docs: fix 29 typos in English documentation and code examples

### DIFF
--- a/dubbo-dev-book-en/SPI.md
+++ b/dubbo-dev-book-en/SPI.md
@@ -8,17 +8,17 @@ Dubbo SPI is inherited from standard JDK SPI(Service Provider Interface) and mak
 
 Dubbo fixed below issues of the standard JDK SPI：
 
-* the standard JDK  SPI will load  and instantize all implementation at once. It will be a waste of resources if the implementation is timecosted ,but never be used.
-* We cann't accquire the SPI name,if loading the SPI implementation is failed.For example：standard JDK  ScriptEngine，get script type by invoking method getName(). RubyScriptEngine class will load failed if the depenency jar jruby.jar is missing，and the real error info will be lost. When user executes ruby scripts , program throws exception , telling not support ruby, but it is not the real cause.
+* the standard JDK  SPI will load  and instantiate all implementation at once. It will be a waste of resources if the implementation is timecosted ,but never be used.
+* We can't acquire the SPI name,if loading the SPI implementation is failed.For example：standard JDK  ScriptEngine，get script type by invoking method getName(). RubyScriptEngine class will load failed if the dependency jar jruby.jar is missing，and the real error info will be lost. When user executes ruby scripts , program throws exception , telling not support ruby, but it is not the real cause.
 * Enhance the SPI functionality by supporting  IoC and AOP ，one SPI can be easily injected by another SPI simply using  setter.
 
 ### Appointment：
 
-In the jar file containing extension class [^1]，places a config file  `META-INF/dubbo/full interface name`，file content pattern：`SPI name=the fully qualified name for the extension class`，use new line seperator for multiple implementation.
+In the jar file containing extension class [^1]，places a config file  `META-INF/dubbo/full interface name`，file content pattern：`SPI name=the fully qualified name for the extension class`，use new line separator for multiple implementation.
 
 ### Example：
 
-To extend  Dubbo Protocol，placee a text file in the extension jar file：`META-INF/dubbo/com.alibaba.dubbo.rpc.Protocol`，content：
+To extend  Dubbo Protocol，place a text file in the extension jar file：`META-INF/dubbo/com.alibaba.dubbo.rpc.Protocol`，content：
 
 ```properties
 xxx=com.alibaba.xxx.XxxProtocol
@@ -31,7 +31,7 @@ package com.alibaba.xxx;
  
 import com.alibaba.dubbo.rpc.Protocol;
  
-public class XxxProtocol implemenets Protocol { 
+public class XxxProtocol implements Protocol { 
     // ...
 }
 ```
@@ -48,7 +48,7 @@ In Dubbo config module，all SPI points have related attributes or labels，we c
 
 ### SPI Auto Wrap
 
-Auto wrap the SPI's Wrapper class。`ExtensionLoader`  loads the SPI implementation，if the SPI has a copy instructor ,it will be regarded as the SPI's Wrapper class。
+Auto wrap the SPI's Wrapper class。`ExtensionLoader`  loads the SPI implementation，if the SPI has a copy constructor ,it will be regarded as the SPI's Wrapper class。
 
 Wrapper class content：
 
@@ -57,7 +57,7 @@ package com.alibaba.xxx;
  
 import com.alibaba.dubbo.rpc.Protocol;
  
-public class XxxProtocolWrapper implemenets Protocol {
+public class XxxProtocolWrapper implements Protocol {
     Protocol impl;
  
     public XxxProtocol(Protocol protocol) { impl = protocol; }
@@ -73,19 +73,19 @@ public class XxxProtocolWrapper implemenets Protocol {
 }
 ```
 
-Wrapper class also implements the same SPI interface，but Wrapper is not the real implementation。It is used for wrap the real  implementation  returned from the `ExtensionLoader` 。The real returned instance by   `ExtensionLoader`  is the Wrapper class instance，Wrapper holder the real SPI implementation class。
+Wrapper class also implements the same SPI interface，but Wrapper is not the real implementation。It is used for wrap the real  implementation  returned from the `ExtensionLoader` 。The real returned instance by   `ExtensionLoader`  is the Wrapper class instance，Wrapper holds the real SPI implementation class。
 
 There can be many Wrapper for one spi, simply add one if you need。
 
-By Wrapper class,you will be able move same logics into Wrapper for all SPIs。Newly added Wrapper class add external logics for all spis, looks like  AOP， Wrapper acts as a proxy for SPI.
+By Wrapper class,you will be able to move same logics into Wrapper for all SPIs。Newly added Wrapper class add external logics for all spis, looks like  AOP， Wrapper acts as a proxy for SPI.
 
 ### SPI Auto Load
 
-when loading the SPI，Dubbo will auto load the depency SPI. When one SPI implementation contains attribute which is also an SPI of another type,`ExtensionLoader` will automatically load the depency SPI.`ExtensionLoader` knows all the members of the specific SPI by scanning the setter method of all implementation class.
+when loading the SPI，Dubbo will auto load the dependency SPI. When one SPI implementation contains attribute which is also an SPI of another type,`ExtensionLoader` will automatically load the dependency SPI.`ExtensionLoader` knows all the members of the specific SPI by scanning the setter method of all implementation class.
 
 Demo：two SPI  `CarMaker`（car maker）、`WheelMaker` (wheel maker)
 
-Intefaces look like：
+Interfaces look like：
 
 ```java
 public interface CarMaker {
@@ -100,7 +100,7 @@ public interface WheelMaker {
 `CarMaker`  implementation：
 
 ```java
-public class RaceCarMaker implemenets CarMaker {
+public class RaceCarMaker implements CarMaker {
     WheelMaker wheelMaker;
  
     public setWheelMaker(WheelMaker wheelMaker) {
@@ -118,13 +118,13 @@ public class RaceCarMaker implemenets CarMaker {
 
 when`ExtensionLoader` loading `CarMaker`  implementation `RaceCar` ，`setWheelMaker`  needs paramType `WheelMaker`  which is also an SPI, It will be automatically loaded .
 
-This brings a new question:How `ExtensionLoader` determines which implementation to use when load the injected SPI。As for this demo, when existing multi `WheelMaker`  implementation, which one should the `ExtensionLoader`  chooses.
+This brings a new question:How `ExtensionLoader` determines which implementation to use when load the injected SPI。As for this demo, when existing multi `WheelMaker`  implementation, which one should the `ExtensionLoader`  choose.
 
 Good question ,we will explain it in the following chapter: SPI Auto Adaptive.
 
 ### SPI Auto Adaptive
 
-The depency SPI that `ExtensionLoader`  injects is an instance of `Adaptive`，the real spi implementation is known until the adaptive instance is be executed.
+The dependency SPI that `ExtensionLoader`  injects is an instance of `Adaptive`，the real spi implementation is known until the adaptive instance is executed.
 
 Dubbo  use URL (containing Key-Value) to pass the configuration.
 
@@ -149,7 +149,7 @@ public interface WheelMaker {
 `CarMaker`  implementation：
 
 ```java
-public class RaceCarMaker implemenets CarMaker {
+public class RaceCarMaker implements CarMaker {
     WheelMaker wheelMaker;
  
     public setWheelMaker(WheelMaker wheelMaker) {
@@ -189,7 +189,7 @@ public interface Transporter {
 }
 ```
 
-for the method bind(),Adaptive will firstly search `server` key，if no Key  were founded then will search `transport` key ，to determine the implementation that the proxy represent for.
+for the method bind(),Adaptive will firstly search `server` key，if no Key  were found then will search `transport` key ，to determine the implementation that the proxy represent for.
 
 
 ### SPI Auto Activation
@@ -212,7 +212,7 @@ Or：
 import com.alibaba.dubbo.common.extension.Activate;
 import com.alibaba.dubbo.rpc.Filter;
  
-@Activate("xxx") // when configed xxx parameter and the parameter has a valid value,the SPI is activated，for example configed cache="lru"，auto acitivate CacheFilter。
+@Activate("xxx") // when configed xxx parameter and the parameter has a valid value,the SPI is activated，for example configed cache="lru"，auto activate CacheFilter。
 public class XxxFilter implements Filter {
     // ...
 }

--- a/dubbo-dev-book-en/implementation.md
+++ b/dubbo-dev-book-en/implementation.md
@@ -10,7 +10,7 @@ All Dubbo tags are parsed by `DubboBeanDefinitionParser`, based on one to one at
 
 Transfer Bean object to URL, and transfer all attributes of Bean to URL parameters when `ServiceConfig.export()` or `ReferenceConfig.get()` initialization.
 
-Then pase URL to [Protocol extension point](./impls/protocol.md), based on [Extension point adaptive mechanism](./SPI.md) of extension point, processing service exposure or reference for different protocols according to URL protocol header.
+Then pass URL to [Protocol extension point](./impls/protocol.md), based on [Extension point adaptive mechanism](./SPI.md) of extension point, processing service exposure or reference for different protocols according to URL protocol header.
 
 ### Service Exposure
 
@@ -56,7 +56,7 @@ Based on `ProtocolFilterWrapper` class, make all `Filter` as chain, call the rea
 
 Based on `ProtocolListenerWrapper` class, make all `InvokerListener` and `ExporterListener` as list, perform call back before and after exposure and reference.
 
-All additional functions would be implementated by `Filter`, including Monitor.
+All additional functions would be implemented by `Filter`, including Monitor.
 
 ## RPC details
 
@@ -72,11 +72,11 @@ The key of Dubbo processing service exposure is the process of converting `Invok
 
 #### Dubbo implementation
 
-The transformation from `Invoker` of Dubbo protocol to `Exporter` takes place in the `export` method of `DubboProtocol` class, it mainly opens the socket to listen service and receive all kinds of requests sent by the client, and the communication details are implementated by Dubbo itself.
+The transformation from `Invoker` of Dubbo protocol to `Exporter` takes place in the `export` method of `DubboProtocol` class, it mainly opens the socket to listen service and receive all kinds of requests sent by the client, and the communication details are implemented by Dubbo itself.
 
 #### RMI implementation
 
-The transformation from `Invoker` of RMI protocol to `Exporter` takes place in the `export` method of `RmiProtocol` class, the RMI service is implementated by Spring, Dubbo or JDK, and the communication details are implementated by JDK, which saves a lot of work.
+The transformation from `Invoker` of RMI protocol to `Exporter` takes place in the `export` method of `RmiProtocol` class, the RMI service is implemented by Spring, Dubbo or JDK, and the communication details are implemented by JDK, which saves a lot of work.
 
 ### The detail process of serving service for service consumer
 
@@ -115,7 +115,7 @@ public class DemoClientAction {
 }
 ```
 
-The `DemoService` in above code is the proxy of service consumer in above image, user can call `Invoker` [^5] which implementate the real RPC by the proxy.
+The `DemoService` in above code is the proxy of service consumer in above image, user can call `Invoker` [^5] which implements the real RPC by the proxy.
 
 Service provider code:
 
@@ -128,7 +128,7 @@ public class DemoServiceImpl implements DemoService {
 }
 ```
 
-The above class would be encapsulated to be a `AbstractProxyInvoker` instance, and create a new `Exporter` instance, then find corresponding `Exporter` instance and call its corresponding `AbstractProxyInvoker` instance when network communication layer recieve request, so that real call service provider code. There are some other `Invoker` classes, but the above 2 are the most important.
+The above class would be encapsulated to be a `AbstractProxyInvoker` instance, and create a new `Exporter` instance, then find corresponding `Exporter` instance and call its corresponding `AbstractProxyInvoker` instance when network communication layer receive request, so that real call service provider code. There are some other `Invoker` classes, but the above 2 are the most important.
 
 ## Remote communication details 
 
@@ -140,7 +140,7 @@ The above class would be encapsulated to be a `AbstractProxyInvoker` instance, a
 
 ![/dev-guide/images/dubbo-protocol.jpg](sources/images/dubbo-protocol.jpg)
 
-* Dispather: `all`, `direct`, `message`, `execution`, `connection`
+* Dispatcher: `all`, `direct`, `message`, `execution`, `connection`
 * ThreadPool: `fixed`, `cached`
 
 

--- a/dubbo-dev-book/SPI.md
+++ b/dubbo-dev-book/SPI.md
@@ -31,7 +31,7 @@ package com.alibaba.xxx;
  
 import com.alibaba.dubbo.rpc.Protocol;
  
-public class XxxProtocol implemenets Protocol { 
+public class XxxProtocol implements Protocol { 
     // ...
 }
 ```
@@ -57,7 +57,7 @@ package com.alibaba.xxx;
  
 import com.alibaba.dubbo.rpc.Protocol;
  
-public class XxxProtocolWrapper implemenets Protocol {
+public class XxxProtocolWrapper implements Protocol {
     Protocol impl;
  
     public XxxProtocol(Protocol protocol) { impl = protocol; }
@@ -100,7 +100,7 @@ public interface WheelMaker {
 `CarMaker` 的一个实现类：
 
 ```java
-public class RaceCarMaker implemenets CarMaker {
+public class RaceCarMaker implements CarMaker {
     WheelMaker wheelMaker;
  
     public setWheelMaker(WheelMaker wheelMaker) {
@@ -149,7 +149,7 @@ public interface WheelMaker {
 `CarMaker` 的一个实现类：
 
 ```java
-public class RaceCarMaker implemenets CarMaker {
+public class RaceCarMaker implements CarMaker {
     WheelMaker wheelMaker;
  
     public setWheelMaker(WheelMaker wheelMaker) {

--- a/dubbo-dev-book/impls/registry.md
+++ b/dubbo-dev-book/impls/registry.md
@@ -149,7 +149,7 @@ src
     |-java
         |-com
             |-xxx
-                |-XxxRegistryFactoryjava (实现RegistryFactory接口)
+                |-XxxRegistryFactory.java (实现RegistryFactory接口)
                 |-XxxRegistry.java (实现Registry接口)
     |-resources
         |-META-INF


### PR DESCRIPTION
## Summary

Fix typos and grammar errors across 4 documentation files:

- **dubbo-dev-book-en/SPI.md** — 17 fixes: `implemenets` → `implements` (×4), `cann't accquire` → `can't acquire`, `depenency`/`depency` → `dependency`, `seperator` → `separator`, `copy instructor` → `copy constructor`, `Intefaces` → `Interfaces`, `acitivate` → `activate`, and grammar fixes
- **dubbo-dev-book-en/implementation.md** — 7 fixes: `implementated` → `implemented` (×3), `implementate` → `implements`, `pase` → `pass`, `recieve` → `receive`, `Dispather` → `Dispatcher`
- **dubbo-dev-book/SPI.md** — 4 fixes: `implemenets` → `implements` in Java code examples
- **dubbo-dev-book/impls/registry.md** — 1 fix: `XxxRegistryFactoryjava` → `XxxRegistryFactory.java`

No functional changes — documentation and code examples only.